### PR TITLE
refactor: Convert function expressions to declarations

### DIFF
--- a/app/components/SessionList.vue
+++ b/app/components/SessionList.vue
@@ -28,31 +28,31 @@ const emit = defineEmits<{
 }>()
 
 // Methods
-const updateStartTime = (session: TimeSession, timeString: string) => {
+function updateStartTime(session: TimeSession, timeString: string) {
 	const newStartTime = parseTimeInput(timeString)
 	if (newStartTime) {
 		emit('updateSession', session, { startTime: newStartTime })
 	}
 }
 
-const updateEndTime = (session: TimeSession, timeString: string) => {
+function updateEndTime(session: TimeSession, timeString: string) {
 	const newEndTime = parseTimeInput(timeString)
 	if (newEndTime) {
 		emit('updateSession', session, { endTime: newEndTime })
 	}
 }
 
-const deleteSession = (session: TimeSession) => {
+function deleteSession(session: TimeSession) {
 	if (confirm('Are you sure you want to delete this session?')) {
 		emit('deleteSession', session)
 	}
 }
 
-const addManualSession = () => {
+function addManualSession() {
 	emit('addManualSession')
 }
 
-const getDurationDisplay = (session: TimeSession): string => {
+function getDurationDisplay(session: TimeSession): string {
 	if (session.isActive) {
 		return 'Running...'
 	}
@@ -65,7 +65,7 @@ const getDurationDisplay = (session: TimeSession): string => {
 	return '--:--:--'
 }
 
-const getSessionErrors = (session: TimeSession): ValidationError[] => {
+function getSessionErrors(session: TimeSession): ValidationError[] {
 	if (!session.endTime) return []
 
 	return validateTimeRange(session.startTime, session.endTime)

--- a/app/components/TimeInput.vue
+++ b/app/components/TimeInput.vue
@@ -28,7 +28,7 @@ const hasError = computed(() => {
 })
 
 // Methods
-const startEdit = () => {
+function startEdit() {
 	if (props.disabled) return
 
 	isEditing.value = true
@@ -40,19 +40,19 @@ const startEdit = () => {
 	})
 }
 
-const finishEdit = () => {
+function finishEdit() {
 	if (isValidTimeFormat(editValue.value)) {
 		emit('update', editValue.value)
 	}
 	isEditing.value = false
 }
 
-const cancelEdit = () => {
+function cancelEdit() {
 	isEditing.value = false
 	editValue.value = ''
 }
 
-const isValidTimeFormat = (timeString: string): boolean => {
+function isValidTimeFormat(timeString: string): boolean {
 	const pattern = /^([01]?\d|2[0-3]):([0-5]\d)$/
 	return pattern.test(timeString)
 }

--- a/app/components/TimerDisplay.vue
+++ b/app/components/TimerDisplay.vue
@@ -23,7 +23,7 @@ const emit = defineEmits<{
 }>()
 
 // Methods
-const toggleTimer = () => {
+function toggleTimer() {
 	emit('toggleTimer')
 }
 </script>

--- a/app/components/WeeklyView.vue
+++ b/app/components/WeeklyView.vue
@@ -65,19 +65,19 @@ const totalSessions = computed(() => {
 })
 
 // Methods
-const previousWeek = () => {
+function previousWeek() {
 	emit('previousWeek')
 }
 
-const nextWeek = () => {
+function nextWeek() {
 	emit('nextWeek')
 }
 
-const selectDay = (date: string) => {
+function selectDay(date: string) {
 	emit('selectDay', date)
 }
 
-const formatWeekRange = (start: Date, end: Date): string => {
+function formatWeekRange(start: Date, end: Date): string {
 	const startStr = start.toLocaleDateString('en-US', {
 		month: 'short',
 		day: 'numeric',
@@ -89,7 +89,7 @@ const formatWeekRange = (start: Date, end: Date): string => {
 	return `${startStr} - ${endStr}`
 }
 
-const formatDate = (dateString: string): string => {
+function formatDate(dateString: string): string {
 	const date = new Date(dateString)
 	return date.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })
 }

--- a/app/composables/useTimeTracker.ts
+++ b/app/composables/useTimeTracker.ts
@@ -54,7 +54,7 @@ export function useTimeTracker() {
 	})
 
 	// Methods
-	const initializeTimer = async () => {
+	async function initializeTimer() {
 		try {
 			loading.value = true
 			await initDatabase()
@@ -69,7 +69,7 @@ export function useTimeTracker() {
 		}
 	}
 
-	const loadActiveSession = async () => {
+	async function loadActiveSession() {
 		try {
 			const activeSession = await getActiveSession()
 			if (activeSession) {
@@ -86,7 +86,7 @@ export function useTimeTracker() {
 		}
 	}
 
-	const toggleTimer = async () => {
+	async function toggleTimer() {
 		try {
 			loading.value = true
 			error.value = ''
@@ -103,7 +103,7 @@ export function useTimeTracker() {
 		}
 	}
 
-	const startTimer = async () => {
+	async function startTimer() {
 		const now = new Date()
 		const sessionData = {
 			startTime: now,
@@ -125,7 +125,7 @@ export function useTimeTracker() {
 		await refreshCurrentDateSessions()
 	}
 
-	const pauseTimer = async () => {
+	async function pauseTimer() {
 		if (!timerState.value.currentSession) return
 
 		const endTime = new Date()
@@ -146,22 +146,20 @@ export function useTimeTracker() {
 		await refreshCurrentDateSessions()
 	}
 
-	const loadSessionsForDate = async (date: string) => {
+	async function loadSessionsForDate(date: string) {
 		try {
-			sessions.value = await getSessionsByDate(date)
+			const dateSessions = await getSessionsByDate(date)
+			sessions.value = dateSessions
 		} catch (err) {
-			error.value = `Failed to load sessions: ${
-				err instanceof Error ? err.message : 'Unknown error'
-			}`
+			error.value = `Failed to load sessions: ${err instanceof Error ? err.message : 'Unknown error'}`
 		}
 	}
 
-	const refreshCurrentDateSessions = async () => {
+	async function refreshCurrentDateSessions() {
 		await loadSessionsForDate(selectedDate.value)
-		await loadWeeklyStats()
 	}
 
-	const updateSessionData = async (session: TimeSession, updates: Partial<TimeSession>) => {
+	async function updateSessionData(session: TimeSession, updates: Partial<TimeSession>) {
 		try {
 			loading.value = true
 			error.value = ''
@@ -181,6 +179,7 @@ export function useTimeTracker() {
 
 			await updateSession(session.id, updates)
 			await refreshCurrentDateSessions()
+			await loadWeeklyStats()
 		} catch (err) {
 			error.value = `Failed to update session: ${
 				err instanceof Error ? err.message : 'Unknown error'
@@ -190,13 +189,14 @@ export function useTimeTracker() {
 		}
 	}
 
-	const deleteSessionData = async (session: TimeSession) => {
+	async function deleteSessionData(session: TimeSession) {
 		try {
 			loading.value = true
 			error.value = ''
 
 			await deleteSessionFromDB(session.id)
 			await refreshCurrentDateSessions()
+			await loadWeeklyStats()
 		} catch (err) {
 			error.value = `Failed to delete session: ${
 				err instanceof Error ? err.message : 'Unknown error'
@@ -206,7 +206,7 @@ export function useTimeTracker() {
 		}
 	}
 
-	const addManualSession = async () => {
+	async function addManualSession() {
 		const now = new Date()
 		const startTime = new Date(now.getTime() - 60 * 60 * 1000) // 1 hour ago
 		const endTime = now
@@ -234,6 +234,7 @@ export function useTimeTracker() {
 
 			await saveSession(sessionData)
 			await refreshCurrentDateSessions()
+			await loadWeeklyStats()
 		} catch (err) {
 			error.value = `Failed to add session: ${err instanceof Error ? err.message : 'Unknown error'}`
 		} finally {
@@ -241,7 +242,7 @@ export function useTimeTracker() {
 		}
 	}
 
-	const loadWeeklyStats = async () => {
+	async function loadWeeklyStats() {
 		try {
 			const weekStartStr = formatDate(weekStart.value)
 			const weekEndStr = formatDate(weekEnd.value)
@@ -292,19 +293,19 @@ export function useTimeTracker() {
 		}
 	}
 
-	const selectDate = async (date: string) => {
+	async function selectDate(date: string) {
 		selectedDate.value = date
 		await loadSessionsForDate(date)
 	}
 
-	const navigateWeek = async (direction: 'prev' | 'next') => {
+	async function navigateWeek(direction: 'prev' | 'next') {
 		const days = direction === 'prev' ? -7 : 7
 		weekStart.value = new Date(weekStart.value.getTime() + days * 24 * 60 * 60 * 1000)
 		weekEnd.value = new Date(weekEnd.value.getTime() + days * 24 * 60 * 60 * 1000)
 		await loadWeeklyStats()
 	}
 
-	const startTimerInterval = () => {
+	function startTimerInterval() {
 		if (timerInterval) clearInterval(timerInterval)
 		timerInterval = window.setInterval(() => {
 			// Force reactivity update for real-time timer display
@@ -315,7 +316,7 @@ export function useTimeTracker() {
 		}, 1000)
 	}
 
-	const stopTimerInterval = () => {
+	function stopTimerInterval() {
 		if (timerInterval) {
 			clearInterval(timerInterval)
 			timerInterval = null

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -30,7 +30,7 @@ watch(selectedDate, (newDate) => {
 	selectedDateInput.value = newDate
 })
 
-const handleDateChange = () => {
+function handleDateChange() {
 	selectDate(selectedDateInput.value)
 }
 

--- a/app/pages/weekly.vue
+++ b/app/pages/weekly.vue
@@ -43,11 +43,11 @@ const mostProductiveDay = computed(() => {
 })
 
 // Methods
-const selectDay = (date: string) => {
+function selectDay(date: string) {
 	selectDate(date)
 }
 
-const formatSelectedDate = (dateString: string): string => {
+function formatSelectedDate(dateString: string): string {
 	const date = new Date(dateString)
 	return date.toLocaleDateString('en-US', {
 		weekday: 'long',
@@ -57,7 +57,7 @@ const formatSelectedDate = (dateString: string): string => {
 	})
 }
 
-const getSessionDuration = (session: TimeSession): string => {
+function getSessionDuration(session: TimeSession): string {
 	if (session.isActive) {
 		return 'Running...'
 	}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -45,7 +45,7 @@ export interface SessionEdit {
 	endTime: Date
 }
 
-export const formatDuration = (milliseconds: number): string => {
+export function formatDuration(milliseconds: number): string {
 	if (milliseconds <= 0) return '0:00:00'
 
 	const totalSeconds = Math.floor(milliseconds / 1000)
@@ -53,12 +53,14 @@ export const formatDuration = (milliseconds: number): string => {
 	const minutes = Math.floor((totalSeconds % 3600) / 60)
 	const seconds = totalSeconds % 60
 
-	const pad = (num: number): string => (num < 10 ? `0${num}` : `${num}`)
+	function pad(num: number): string {
+		return num < 10 ? `0${num}` : `${num}`
+	}
 
 	return `${hours}:${pad(minutes)}:${pad(seconds)}`
 }
 
-export const formatTime = (date: Date): string => {
+export function formatTime(date: Date): string {
 	return date.toLocaleTimeString('en-US', {
 		hour12: false,
 		hour: '2-digit',
@@ -66,12 +68,12 @@ export const formatTime = (date: Date): string => {
 	})
 }
 
-export const formatDate = (date?: Date): string => {
+export function formatDate(date?: Date): string {
 	if (!date) return ''
 	return date.toISOString().split('T')[0] || ''
 }
 
-export const parseTimeInput = (timeString: string): Date | null => {
+export function parseTimeInput(timeString: string): Date | null {
 	const match = timeString.match(/^(\d{1,2}):(\d{2})$/)
 	if (!match) return null
 
@@ -85,11 +87,11 @@ export const parseTimeInput = (timeString: string): Date | null => {
 	return result
 }
 
-export const calculateDuration = (startTime: Date, endTime: Date): number => {
+export function calculateDuration(startTime: Date, endTime: Date): number {
 	return Math.max(0, endTime.getTime() - startTime.getTime())
 }
 
-export const validateTimeRange = (startTime: Date, endTime: Date): ValidationError[] => {
+export function validateTimeRange(startTime: Date, endTime: Date): ValidationError[] {
 	const errors: ValidationError[] = []
 
 	if (startTime >= endTime) {


### PR DESCRIPTION
Convert function expressions to function declarations to adhere to `@typescript.mdc` styling rules.