### PR TITLE
chore: disable directory auto-import scan and require explicit imports

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -6,4 +6,5 @@
 	"semi": false,
 	"printWidth": 100,
 	"singleAttributePerLine": true,
+	"sortImports": true,
 }

--- a/app/app.vue
+++ b/app/app.vue
@@ -2,6 +2,7 @@
 import type { NavigationMenuItem } from '@nuxt/ui'
 import { Timer } from 'lucide-vue-next'
 import { onMounted } from 'vue'
+
 import { useTimerFavicon } from '~/composables/useTimerFavicon.ts'
 import { useTimerState } from '~/composables/useTimerState.ts'
 import { initDatabase } from '~/utils/database.ts'

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { NavigationMenuItem } from '@nuxt/ui'
 import { Timer } from 'lucide-vue-next'
-import { onMounted } from 'vue'
 
 import { useTimerFavicon } from '~/composables/useTimerFavicon.ts'
 import { useTimerState } from '~/composables/useTimerState.ts'

--- a/app/components/AppDateInput.vue
+++ b/app/components/AppDateInput.vue
@@ -8,6 +8,7 @@
  */
 
 import { type CalendarDate, DateFormatter, getLocalTimeZone } from '@internationalized/date'
+
 import type { DateString } from '~/types/index.ts'
 import { calendarDateToDateString } from '~/utils/calendarDateToDateString.ts'
 import { dateStringToCalendarDate } from '~/utils/dateStringToCalendarDate.ts'

--- a/app/components/DaySummaryCard.spec.ts
+++ b/app/components/DaySummaryCard.spec.ts
@@ -1,7 +1,9 @@
 import userEvent from '@testing-library/user-event'
 import { cleanup, render, screen } from '@testing-library/vue'
 import { afterEach, describe, expect, it } from 'vitest'
+
 import type { WeekDay } from '~/types/index.ts'
+
 import DaySummaryCard from './DaySummaryCard.vue'
 
 // Clean up after each test

--- a/app/components/SessionList.vue
+++ b/app/components/SessionList.vue
@@ -4,6 +4,7 @@
  */
 
 import { Clock } from 'lucide-vue-next'
+
 import type { TimeSession } from '~/types/index.ts'
 import { calculateDuration } from '~/utils/calculateDuration.ts'
 import { formatDuration } from '~/utils/formatDuration.ts'
@@ -11,6 +12,7 @@ import { formatTime } from '~/utils/formatTime.ts'
 import { parseTimeInput } from '~/utils/parseTimeInput.ts'
 import type { ValidationError } from '~/utils/validateTimeRange.ts'
 import { validateTimeRange } from '~/utils/validateTimeRange.ts'
+
 import TimeInput from './TimeInput.vue'
 
 withDefaults(

--- a/app/components/ThemeToggle.vue
+++ b/app/components/ThemeToggle.vue
@@ -9,6 +9,7 @@
 
 import { Moon, Sun } from 'lucide-vue-next'
 import { computed } from 'vue'
+
 import { useTheme } from '../composables/useTheme.ts'
 
 const { isDark, toggleTheme } = useTheme()

--- a/app/components/ThemeToggle.vue
+++ b/app/components/ThemeToggle.vue
@@ -8,7 +8,6 @@
  */
 
 import { Moon, Sun } from 'lucide-vue-next'
-import { computed } from 'vue'
 
 import { useTheme } from '../composables/useTheme.ts'
 

--- a/app/components/TimeInput.vue
+++ b/app/components/TimeInput.vue
@@ -3,8 +3,6 @@
  * TimeInput provides an editable time input field that allows users to enter and modify time values in HH:MM format.
  */
 
-import { computed, nextTick, ref, useTemplateRef } from 'vue'
-
 const props = withDefaults(
 	defineProps<{
 		value: string
@@ -72,7 +70,7 @@ function isValidTimeFormat(timeString: string): boolean {
 			@blur="finishEdit"
 			@keydown.enter="finishEdit"
 			@keydown.escape="cancelEdit"
-		/>
+		>
 		<span
 			v-else-if="props.readonly"
 			class="input border input-sm w-20 text-lg content-center grid font-mono bg-transparent border-transparent text-center"

--- a/app/components/TimeInput.vue
+++ b/app/components/TimeInput.vue
@@ -72,7 +72,7 @@ function isValidTimeFormat(timeString: string): boolean {
 			@blur="finishEdit"
 			@keydown.enter="finishEdit"
 			@keydown.escape="cancelEdit"
-		>
+		/>
 		<span
 			v-else-if="props.readonly"
 			class="input border input-sm w-20 text-lg content-center grid font-mono bg-transparent border-transparent text-center"

--- a/app/components/WeekRangeButtons.vue
+++ b/app/components/WeekRangeButtons.vue
@@ -4,6 +4,7 @@
  */
 
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
+
 import { formatDate } from '~/utils/formatDate.ts'
 
 const props = defineProps<{

--- a/app/components/WeeklyView.vue
+++ b/app/components/WeeklyView.vue
@@ -3,9 +3,11 @@
  * WeeklyView displays a comprehensive weekly overview of time tracking data including daily summaries and navigation controls.
  */
 import { computed } from 'vue'
+
 import type { DateString, DayStats, WeekDay } from '~/types/index.ts'
 import { convertToDateString } from '~/utils/convertToDateString.ts'
 import { formatDuration } from '~/utils/formatDuration.ts'
+
 import AppCard from './AppCard.vue'
 import DaySummaryCard from './DaySummaryCard.vue'
 import WeekRangeButtons from './WeekRangeButtons.vue'

--- a/app/components/WeeklyView.vue
+++ b/app/components/WeeklyView.vue
@@ -2,8 +2,6 @@
 /**
  * WeeklyView displays a comprehensive weekly overview of time tracking data including daily summaries and navigation controls.
  */
-import { computed } from 'vue'
-
 import type { DateString, DayStats, WeekDay } from '~/types/index.ts'
 import { convertToDateString } from '~/utils/convertToDateString.ts'
 import { formatDuration } from '~/utils/formatDuration.ts'

--- a/app/composables/useMonthlyStats.ts
+++ b/app/composables/useMonthlyStats.ts
@@ -1,4 +1,5 @@
 import { type Ref, shallowReadonly, shallowRef } from 'vue'
+
 import type { Milliseconds, MonthStats } from '../types/index.ts'
 import { convertToDateString } from '../utils/convertToDateString.ts'
 import { getSessionsInDateRange } from '../utils/database.ts'

--- a/app/composables/useMonthlyStats.ts
+++ b/app/composables/useMonthlyStats.ts
@@ -1,5 +1,3 @@
-import { type Ref, shallowReadonly, shallowRef } from 'vue'
-
 import type { Milliseconds, MonthStats } from '../types/index.ts'
 import { convertToDateString } from '../utils/convertToDateString.ts'
 import { getSessionsInDateRange } from '../utils/database.ts'

--- a/app/composables/useSessionManager.ts
+++ b/app/composables/useSessionManager.ts
@@ -1,4 +1,5 @@
 import { type Ref, shallowReadonly, shallowRef } from 'vue'
+
 import type { DateString, TimeSession } from '../types/index.ts'
 import { convertToDateString } from '../utils/convertToDateString.ts'
 import {

--- a/app/composables/useSessionManager.ts
+++ b/app/composables/useSessionManager.ts
@@ -1,5 +1,3 @@
-import { type Ref, shallowReadonly, shallowRef } from 'vue'
-
 import type { DateString, TimeSession } from '../types/index.ts'
 import { convertToDateString } from '../utils/convertToDateString.ts'
 import {

--- a/app/composables/useTheme.ts
+++ b/app/composables/useTheme.ts
@@ -7,7 +7,6 @@
  */
 
 import { useColorMode } from '@vueuse/core'
-import { computed } from 'vue'
 
 const STORAGE_KEY = 'theme-preference'
 

--- a/app/composables/useTimerFavicon.ts
+++ b/app/composables/useTimerFavicon.ts
@@ -1,5 +1,6 @@
 import { useFavicon } from '@vueuse/core'
 import { computed } from 'vue'
+
 import { useTimerState } from '~/composables/useTimerState.ts'
 import { buildTimerFaviconUrl } from '~/utils/buildTimerFaviconUrl.ts'
 

--- a/app/composables/useTimerFavicon.ts
+++ b/app/composables/useTimerFavicon.ts
@@ -1,5 +1,4 @@
 import { useFavicon } from '@vueuse/core'
-import { computed } from 'vue'
 
 import { useTimerState } from '~/composables/useTimerState.ts'
 import { buildTimerFaviconUrl } from '~/utils/buildTimerFaviconUrl.ts'

--- a/app/composables/useTimerState.ts
+++ b/app/composables/useTimerState.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt'
 import { createSharedComposable, useDocumentVisibility, useIntervalFn } from '@vueuse/core'
 import { onMounted, onUnmounted, type Ref, shallowReadonly, shallowRef, watch } from 'vue'
+
 import type { Milliseconds, TimerState } from '../types/index.ts'
 import { convertToDateString } from '../utils/convertToDateString.ts'
 import { getActiveSession, saveSession, updateSession } from '../utils/database.ts'

--- a/app/composables/useTimerState.ts
+++ b/app/composables/useTimerState.ts
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/nuxt'
 import { createSharedComposable, useDocumentVisibility, useIntervalFn } from '@vueuse/core'
-import { onMounted, onUnmounted, type Ref, shallowReadonly, shallowRef, watch } from 'vue'
 
 import type { Milliseconds, TimerState } from '../types/index.ts'
 import { convertToDateString } from '../utils/convertToDateString.ts'

--- a/app/composables/useWeeklyStats.ts
+++ b/app/composables/useWeeklyStats.ts
@@ -1,5 +1,3 @@
-import { type Ref, shallowReadonly, shallowRef } from 'vue'
-
 import type { DayStats, Milliseconds, TimeSession } from '../types/index.ts'
 import { convertToDateString } from '../utils/convertToDateString.ts'
 import { getSessionsInDateRange } from '../utils/database.ts'

--- a/app/composables/useWeeklyStats.ts
+++ b/app/composables/useWeeklyStats.ts
@@ -1,4 +1,5 @@
 import { type Ref, shallowReadonly, shallowRef } from 'vue'
+
 import type { DayStats, Milliseconds, TimeSession } from '../types/index.ts'
 import { convertToDateString } from '../utils/convertToDateString.ts'
 import { getSessionsInDateRange } from '../utils/database.ts'

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { useSum } from '@vueuse/math'
-import { computed, onMounted, watch } from 'vue'
 
 import AppDateInput from '~/components/AppDateInput.vue'
 import SessionList from '~/components/SessionList.vue'

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useSum } from '@vueuse/math'
 import { computed, onMounted, watch } from 'vue'
+
 import AppDateInput from '~/components/AppDateInput.vue'
 import SessionList from '~/components/SessionList.vue'
 import TimerDisplay from '~/components/TimerDisplay.vue'

--- a/app/pages/monthly.vue
+++ b/app/pages/monthly.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
+
 import AppCard from '~/components/AppCard.vue'
 import { useMonthlyStats } from '~/composables/useMonthlyStats.ts'
 import { initDatabase } from '~/utils/database.ts'

--- a/app/pages/monthly.vue
+++ b/app/pages/monthly.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
-
 import AppCard from '~/components/AppCard.vue'
 import { useMonthlyStats } from '~/composables/useMonthlyStats.ts'
 import { initDatabase } from '~/utils/database.ts'

--- a/app/pages/weekly.vue
+++ b/app/pages/weekly.vue
@@ -2,6 +2,7 @@
 import { useSum } from '@vueuse/math'
 import { Calendar } from 'lucide-vue-next'
 import { computed, onMounted } from 'vue'
+
 import AppCard from '~/components/AppCard.vue'
 import WeeklyView from '~/components/WeeklyView.vue'
 import { useSessionManager } from '~/composables/useSessionManager.ts'

--- a/app/pages/weekly.vue
+++ b/app/pages/weekly.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { useSum } from '@vueuse/math'
 import { Calendar } from 'lucide-vue-next'
-import { computed, onMounted } from 'vue'
 
 import AppCard from '~/components/AppCard.vue'
 import WeeklyView from '~/components/WeeklyView.vue'

--- a/app/plugins/color-mode.client.ts
+++ b/app/plugins/color-mode.client.ts
@@ -2,6 +2,7 @@
  * Eagerly initialize color mode on client to avoid attribute/class mismatch and FOUC.
  */
 import { defineNuxtPlugin } from '#app'
+
 import { useTheme } from '../composables/useTheme.ts'
 
 export default defineNuxtPlugin(() => {

--- a/app/utils/calculateDuration.spec.ts
+++ b/app/utils/calculateDuration.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { calculateDuration } from './calculateDuration.ts'
 
 describe('calculateDuration', () => {

--- a/app/utils/calendarDateToDateString.spec.ts
+++ b/app/utils/calendarDateToDateString.spec.ts
@@ -1,5 +1,6 @@
 import { CalendarDate } from '@internationalized/date'
 import { describe, expect, it } from 'vitest'
+
 import { calendarDateToDateString } from './calendarDateToDateString.ts'
 
 describe('calendarDateToDateString', () => {

--- a/app/utils/calendarDateToDateString.ts
+++ b/app/utils/calendarDateToDateString.ts
@@ -1,4 +1,5 @@
 import type { CalendarDate } from '@internationalized/date'
+
 import type { DateString } from '~/types/index.ts'
 
 /**

--- a/app/utils/convertToDateString.spec.ts
+++ b/app/utils/convertToDateString.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { convertToDateString } from './convertToDateString'
 
 describe('convertToDateString', () => {

--- a/app/utils/database.ts
+++ b/app/utils/database.ts
@@ -1,5 +1,6 @@
 import type { Table } from 'dexie'
 import Dexie from 'dexie'
+
 import type { DateString, TimeSession } from '../types/index.ts'
 
 const DB_NAME = 'timeTracker'

--- a/app/utils/dateStringToCalendarDate.spec.ts
+++ b/app/utils/dateStringToCalendarDate.spec.ts
@@ -1,6 +1,8 @@
 import { CalendarDate } from '@internationalized/date'
 import { describe, expect, it } from 'vitest'
+
 import type { DateString } from '~/types/index.ts'
+
 import { dateStringToCalendarDate } from './dateStringToCalendarDate.ts'
 
 describe('dateStringToCalendarDate', () => {

--- a/app/utils/dateStringToCalendarDate.ts
+++ b/app/utils/dateStringToCalendarDate.ts
@@ -1,4 +1,5 @@
 import { CalendarDate } from '@internationalized/date'
+
 import type { DateString } from '~/types/index.ts'
 
 export function dateStringToCalendarDate(dateString: DateString): CalendarDate {

--- a/app/utils/diffInMilliseconds.spec.ts
+++ b/app/utils/diffInMilliseconds.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { diffInMilliseconds } from './diffInMilliseconds.ts'
 
 describe('diffInMilliseconds', () => {

--- a/app/utils/formatDuration.spec.ts
+++ b/app/utils/formatDuration.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { formatDuration } from './formatDuration'
 
 describe('formatDuration', () => {

--- a/app/utils/formatTime.spec.ts
+++ b/app/utils/formatTime.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { formatTime } from './formatTime'
 
 describe('formatTime', () => {

--- a/app/utils/parseTimeInput.spec.ts
+++ b/app/utils/parseTimeInput.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { parseTimeInput } from './parseTimeInput'
 
 describe('parseTimeInput', () => {

--- a/app/utils/validateTimeRange.spec.ts
+++ b/app/utils/validateTimeRange.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { validateTimeRange } from './validateTimeRange'
 
 describe('validateTimeRange', () => {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,6 +23,10 @@ export default defineNuxtConfig({
 	],
 
 	ssr: false,
+
+	imports: {
+		scan: false,
+	},
 	devtools: { enabled: true },
 	css: ['~/assets/css/main.css'],
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path'
+
 import { defineVitestProject } from '@nuxt/test-utils/config'
 import { defineConfig } from 'vitest/config'
 


### PR DESCRIPTION
## Summary

- Enable `imports.scan: false` in `nuxt.config.ts` so only Vue/Nuxt framework APIs remain auto-imported; project composables and utilities must be imported explicitly ([Nuxt partial auto-import docs](https://nuxt.com/docs/4.x/guide/concepts/auto-imports#partially-disabling-auto-imports))
- Remove redundant `vue` import statements across pages, components, and composables (`ref`, `computed`, `watch`, `onMounted`, etc.)
- Enable `sortImports` in `.oxfmtrc.jsonc` and apply consistent import grouping/formatting across the codebase

## Why

Explicit imports improve code clarity and make dependencies visible at a glance. Disabling directory scanning keeps Vue API auto-import convenience while requiring deliberate imports for app-specific modules, aligning with project conventions.

## Risk & impact

- **Low risk** — no runtime behavior changes; import resolution only
- New composables/utils added under `app/composables/` or `app/utils/` will **not** be auto-imported and must be imported manually
- Layer override behavior is unaffected (this project does not use Nuxt layers)

## Test plan

- [x] `pnpm lint:fix`
- [x] `pnpm lint-vue:fix`
- [x] `pnpm typecheck`
- [ ] Smoke-test app: timer start/stop, session list, weekly/monthly views load without import errors

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automatic import sorting in the formatter configuration.
  * Reorganized imports and added formatting consistency across component and utility files through blank line adjustments.
  * Updated Nuxt module configuration to adjust auto-import scanning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->