### PR TITLE
refactor: extract AppDateTimeInput from SessionEditModal

### DIFF
--- a/app/components/AppDateTimeInput.vue
+++ b/app/components/AppDateTimeInput.vue
@@ -10,8 +10,12 @@ import { parseCalendarInput, parseTimeInputValue } from '~/utils/parseCalendarIn
 
 const model = defineModel<Date>({ required: true })
 
-withDefaults(
+const props = withDefaults(
 	defineProps<{
+		/** Accessible name for the date input. */
+		dateAriaLabel: string
+		/** Accessible name for the time input. */
+		timeAriaLabel: string
 		size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
 		color?: 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
 		variant?: 'outline' | 'soft' | 'subtle' | 'ghost' | 'none'
@@ -47,21 +51,23 @@ function updateTime(value: unknown): void {
 	<UFieldGroup class="w-full">
 		<UInputDate
 			:model-value="datePart"
-			:size="size"
-			:color="color"
-			:variant="variant"
+			:size="props.size"
+			:color="props.color"
+			:variant="props.variant"
+			:aria-label="props.dateAriaLabel"
 			class="flex-1"
-			:disabled="disabled"
+			:disabled="props.disabled"
 			@update:model-value="updateDate"
 		/>
 		<UInputTime
 			:model-value="timePart"
-			:size="size"
-			:color="color"
-			:variant="variant"
+			:size="props.size"
+			:color="props.color"
+			:variant="props.variant"
+			:aria-label="props.timeAriaLabel"
 			:hour-cycle="24"
 			class="flex-1"
-			:disabled="disabled"
+			:disabled="props.disabled"
 			@update:model-value="updateTime"
 		/>
 	</UFieldGroup>

--- a/app/components/AppDateTimeInput.vue
+++ b/app/components/AppDateTimeInput.vue
@@ -13,14 +13,7 @@ const model = defineModel<Date>({ required: true })
 withDefaults(
 	defineProps<{
 		size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
-		color?:
-			| 'primary'
-			| 'secondary'
-			| 'success'
-			| 'info'
-			| 'warning'
-			| 'error'
-			| 'neutral'
+		color?: 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
 		variant?: 'outline' | 'soft' | 'subtle' | 'ghost' | 'none'
 		disabled?: boolean
 	}>(),

--- a/app/components/AppDateTimeInput.vue
+++ b/app/components/AppDateTimeInput.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+/**
+ * Combined date and time input using UInputDate and UInputTime in a field group.
+ */
+
+import { combineDateAndTime } from '~/utils/combineDateAndTime.ts'
+import { dateToCalendarDate } from '~/utils/dateToCalendarDate.ts'
+import { dateToTime } from '~/utils/dateToTime.ts'
+import { parseCalendarInput, parseTimeInputValue } from '~/utils/parseCalendarInput.ts'
+
+const model = defineModel<Date>({ required: true })
+
+withDefaults(
+	defineProps<{
+		size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+		color?:
+			| 'primary'
+			| 'secondary'
+			| 'success'
+			| 'info'
+			| 'warning'
+			| 'error'
+			| 'neutral'
+		variant?: 'outline' | 'soft' | 'subtle' | 'ghost' | 'none'
+		disabled?: boolean
+	}>(),
+	{
+		size: 'sm',
+		color: 'neutral',
+		variant: 'subtle',
+		disabled: false,
+	},
+)
+
+const datePart = computed(() => dateToCalendarDate(model.value))
+const timePart = computed(() => dateToTime(model.value))
+
+function updateDate(value: unknown): void {
+	const parsedDate = parseCalendarInput(value)
+	if (parsedDate) {
+		model.value = combineDateAndTime(parsedDate, timePart.value)
+	}
+}
+
+function updateTime(value: unknown): void {
+	const parsedTime = parseTimeInputValue(value)
+	if (parsedTime) {
+		model.value = combineDateAndTime(datePart.value, parsedTime)
+	}
+}
+</script>
+
+<template>
+	<UFieldGroup class="w-full">
+		<UInputDate
+			:model-value="datePart"
+			:size="size"
+			:color="color"
+			:variant="variant"
+			class="flex-1"
+			:disabled="disabled"
+			@update:model-value="updateDate"
+		/>
+		<UInputTime
+			:model-value="timePart"
+			:size="size"
+			:color="color"
+			:variant="variant"
+			:hour-cycle="24"
+			class="flex-1"
+			:disabled="disabled"
+			@update:model-value="updateTime"
+		/>
+	</UFieldGroup>
+</template>

--- a/app/components/SessionEditModal.vue
+++ b/app/components/SessionEditModal.vue
@@ -62,10 +62,10 @@ function resetForm(): void {
 	showValidationErrors.value = false
 
 	if (props.session) {
-		startDateTime.value = props.session.startTime
-		if (props.session.endTime) {
-			endDateTime.value = props.session.endTime
-		}
+		startDateTime.value = new Date(props.session.startTime)
+		endDateTime.value = props.session.endTime
+			? new Date(props.session.endTime)
+			: new Date(props.session.startTime)
 		return
 	}
 
@@ -119,6 +119,8 @@ watch(
 				>
 					<AppDateTimeInput
 						v-model="startDateTime"
+						date-aria-label="Start date"
+						time-aria-label="Start time"
 						size="sm"
 						color="neutral"
 						variant="subtle"
@@ -132,6 +134,8 @@ watch(
 				>
 					<AppDateTimeInput
 						v-model="endDateTime"
+						date-aria-label="End date"
+						time-aria-label="End time"
 						size="sm"
 						color="neutral"
 						variant="subtle"

--- a/app/components/SessionEditModal.vue
+++ b/app/components/SessionEditModal.vue
@@ -41,9 +41,7 @@ const isCreateMode = computed(() => !props.session)
 
 const modalTitle = computed(() => (isCreateMode.value ? 'Add session' : 'Edit session'))
 
-const validationErrors = computed(() =>
-	validateTimeRange(startDateTime.value, endDateTime.value),
-)
+const validationErrors = computed(() => validateTimeRange(startDateTime.value, endDateTime.value))
 
 const durationDisplay = computed(() => {
 	if (validationErrors.value.length > 0) return '--:--:--'

--- a/app/components/SessionEditModal.vue
+++ b/app/components/SessionEditModal.vue
@@ -3,16 +3,11 @@
  * Modal for creating or editing a time tracking session with full date and time control.
  */
 
-import { CalendarDate, Time } from '@internationalized/date'
-
+import AppDateTimeInput from '~/components/AppDateTimeInput.vue'
 import type { DateString, TimeSession } from '~/types/index.ts'
 import { calculateDuration } from '~/utils/calculateDuration.ts'
-import { combineDateAndTime } from '~/utils/combineDateAndTime.ts'
-import { dateToCalendarDate } from '~/utils/dateToCalendarDate.ts'
-import { dateToTime } from '~/utils/dateToTime.ts'
 import { formatDuration } from '~/utils/formatDuration.ts'
 import { getDefaultSessionTimes } from '~/utils/getDefaultSessionTimes.ts'
-import { parseCalendarInput, parseTimeInputValue } from '~/utils/parseCalendarInput.ts'
 import { validateTimeRange } from '~/utils/validateTimeRange.ts'
 
 const props = withDefaults(
@@ -39,47 +34,20 @@ const emit = defineEmits<{
 	save: [payload: { startTime: Date; endTime: Date }]
 }>()
 
-const startDate = shallowRef<CalendarDate>(new CalendarDate(1970, 1, 1))
-const startTime = shallowRef<Time>(new Time(0, 0))
-const endDate = shallowRef<CalendarDate>(new CalendarDate(1970, 1, 1))
-const endTime = shallowRef<Time>(new Time(0, 0))
-const showValidationErrors = shallowRef(false)
+const startDateTime = shallowRef<Date>(new Date())
+const endDateTime = shallowRef<Date>(new Date())
 
 const isCreateMode = computed(() => !props.session)
 
 const modalTitle = computed(() => (isCreateMode.value ? 'Add session' : 'Edit session'))
 
-function updateStartDate(value: unknown): void {
-	const parsedDate = parseCalendarInput(value)
-	if (parsedDate) startDate.value = parsedDate
-}
-
-function updateStartTime(value: unknown): void {
-	const parsedTime = parseTimeInputValue(value)
-	if (parsedTime) startTime.value = parsedTime
-}
-
-function updateEndDate(value: unknown): void {
-	const parsedDate = parseCalendarInput(value)
-	if (parsedDate) endDate.value = parsedDate
-}
-
-function updateEndTime(value: unknown): void {
-	const parsedTime = parseTimeInputValue(value)
-	if (parsedTime) endTime.value = parsedTime
-}
-
-const combinedStartTime = computed(() => combineDateAndTime(startDate.value, startTime.value))
-
-const combinedEndTime = computed(() => combineDateAndTime(endDate.value, endTime.value))
-
 const validationErrors = computed(() =>
-	validateTimeRange(combinedStartTime.value, combinedEndTime.value),
+	validateTimeRange(startDateTime.value, endDateTime.value),
 )
 
 const durationDisplay = computed(() => {
 	if (validationErrors.value.length > 0) return '--:--:--'
-	return formatDuration(calculateDuration(combinedStartTime.value, combinedEndTime.value))
+	return formatDuration(calculateDuration(startDateTime.value, endDateTime.value))
 })
 
 const displayedErrors = computed(() => {
@@ -90,24 +58,22 @@ const displayedErrors = computed(() => {
 	return errors
 })
 
+const showValidationErrors = shallowRef(false)
+
 function resetForm(): void {
 	showValidationErrors.value = false
 
 	if (props.session) {
-		startDate.value = dateToCalendarDate(props.session.startTime)
-		startTime.value = dateToTime(props.session.startTime)
+		startDateTime.value = props.session.startTime
 		if (props.session.endTime) {
-			endDate.value = dateToCalendarDate(props.session.endTime)
-			endTime.value = dateToTime(props.session.endTime)
+			endDateTime.value = props.session.endTime
 		}
 		return
 	}
 
 	const { startTime: defaultStart, endTime: defaultEnd } = getDefaultSessionTimes(props.defaultDate)
-	startDate.value = dateToCalendarDate(defaultStart)
-	startTime.value = dateToTime(defaultStart)
-	endDate.value = dateToCalendarDate(defaultEnd)
-	endTime.value = dateToTime(defaultEnd)
+	startDateTime.value = defaultStart
+	endDateTime.value = defaultEnd
 }
 
 function handleSave(): void {
@@ -116,8 +82,8 @@ function handleSave(): void {
 	if (validationErrors.value.length > 0) return
 
 	emit('save', {
-		startTime: combinedStartTime.value,
-		endTime: combinedEndTime.value,
+		startTime: startDateTime.value,
+		endTime: endDateTime.value,
 	})
 }
 
@@ -153,54 +119,26 @@ watch(
 					label="Start"
 					name="start"
 				>
-					<UFieldGroup class="w-full">
-						<UInputDate
-							:model-value="startDate"
-							size="sm"
-							color="neutral"
-							variant="subtle"
-							class="flex-1"
-							:disabled="loading || (session?.isActive ?? false)"
-							@update:model-value="updateStartDate"
-						/>
-						<UInputTime
-							:model-value="startTime"
-							size="sm"
-							color="neutral"
-							variant="subtle"
-							:hour-cycle="24"
-							class="flex-1"
-							:disabled="loading || (session?.isActive ?? false)"
-							@update:model-value="updateStartTime"
-						/>
-					</UFieldGroup>
+					<AppDateTimeInput
+						v-model="startDateTime"
+						size="sm"
+						color="neutral"
+						variant="subtle"
+						:disabled="loading || (session?.isActive ?? false)"
+					/>
 				</UFormField>
 
 				<UFormField
 					label="End"
 					name="end"
 				>
-					<UFieldGroup class="w-full">
-						<UInputDate
-							:model-value="endDate"
-							size="sm"
-							color="neutral"
-							variant="subtle"
-							class="flex-1"
-							:disabled="loading"
-							@update:model-value="updateEndDate"
-						/>
-						<UInputTime
-							:model-value="endTime"
-							size="sm"
-							color="neutral"
-							variant="subtle"
-							:hour-cycle="24"
-							class="flex-1"
-							:disabled="loading"
-							@update:model-value="updateEndTime"
-						/>
-					</UFieldGroup>
+					<AppDateTimeInput
+						v-model="endDateTime"
+						size="sm"
+						color="neutral"
+						variant="subtle"
+						:disabled="loading"
+					/>
 				</UFormField>
 
 				<div class="text-sm text-muted">
@@ -212,7 +150,11 @@ watch(
 					color="error"
 					variant="subtle"
 					icon="i-lucide-circle-alert"
-					:title="displayedErrors.length === 1 ? displayedErrors[0]?.message : 'Please fix the following issues'"
+					:title="
+						displayedErrors.length === 1
+							? displayedErrors[0]?.message
+							: 'Please fix the following issues'
+					"
 				>
 					<template
 						v-if="displayedErrors.length > 1"

--- a/app/components/TimeInput.vue
+++ b/app/components/TimeInput.vue
@@ -70,7 +70,7 @@ function isValidTimeFormat(timeString: string): boolean {
 			@blur="finishEdit"
 			@keydown.enter="finishEdit"
 			@keydown.escape="cancelEdit"
-		>
+		/>
 		<span
 			v-else-if="props.readonly"
 			class="input border input-sm w-20 text-lg content-center grid font-mono bg-transparent border-transparent text-center"

--- a/app/utils/getDefaultSessionTimes.ts
+++ b/app/utils/getDefaultSessionTimes.ts
@@ -25,9 +25,7 @@ export function getDefaultSessionTimes(
 		throw new Error('Invalid date string format')
 	}
 
-	const endTime = isToday
-		? now
-		: new Date(year, month - 1, day, 12, 0, 0)
+	const endTime = isToday ? now : new Date(year, month - 1, day, 12, 0, 0)
 
 	const startTime = new Date(endTime.getTime() - 60 * 60 * 1000)
 

--- a/app/utils/sessionMutations.spec.ts
+++ b/app/utils/sessionMutations.spec.ts
@@ -6,9 +6,8 @@ import { checkForOverlappingSessions, updateSession } from './database.ts'
 import { assertNoOverlappingSessions, persistSessionUpdate } from './sessionMutations'
 
 vi.mock('./database.ts', () => ({
-	checkForOverlappingSessions: vi.fn<
-		(startTime: Date, endTime: Date, excludeId?: number) => Promise<TimeSession[]>
-	>(),
+	checkForOverlappingSessions:
+		vi.fn<(startTime: Date, endTime: Date, excludeId?: number) => Promise<TimeSession[]>>(),
 	updateSession: vi.fn<(id: number, updates: Partial<TimeSession>) => Promise<void>>(),
 }))
 
@@ -64,10 +63,6 @@ describe('persistSessionUpdate', () => {
 
 		await persistSessionUpdate(session, { startTime })
 
-		expect(checkForOverlappingSessions).toHaveBeenCalledWith(
-			startTime,
-			session.endTime,
-			session.id,
-		)
+		expect(checkForOverlappingSessions).toHaveBeenCalledWith(startTime, session.endTime, session.id)
 	})
 })

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,5 +4,13 @@ import withNuxt from './.nuxt/eslint.config.mjs'
 export default withNuxt({
 	rules: {
 		'no-self-assign': 'off', // Checked by Biome
+		'vue/html-self-closing': [
+			'error',
+			{
+				html: {
+					void: 'any',
+				},
+			},
+		],
 	},
 })

--- a/eslint/eslint-clean-json.ts
+++ b/eslint/eslint-clean-json.ts
@@ -12,29 +12,29 @@ export default function (results: ESLintResult[]): string {
 			messages: r.messages,
 			errorCount: r.errorCount,
 			warningCount: r.warningCount,
-		}));
-	return JSON.stringify(filtered, null, 2);
+		}))
+	return JSON.stringify(filtered, null, 2)
 }
 
 interface Message {
-	ruleId: string;
-	severity: "error" | "warning";
-	message: string;
-	line: number;
-	column: number;
-	endLine: number;
-	endColumn: number;
+	ruleId: string
+	severity: 'error' | 'warning'
+	message: string
+	line: number
+	column: number
+	endLine: number
+	endColumn: number
 	fix?: {
-		range: [number, number];
-		text: string;
-	};
-	source: string;
+		range: [number, number]
+		text: string
+	}
+	source: string
 }
 
 interface ESLintResult {
-	filePath: string;
-	messages: Message[];
-	errorCount: number;
-	warningCount: number;
-	source: string;
+	filePath: string
+	messages: Message[]
+	errorCount: number
+	warningCount: number
+	source: string
 }


### PR DESCRIPTION
## Summary

- Extract paired `UInputDate` / `UInputTime` fields into a reusable `AppDateTimeInput` component
- Component exposes default `v-model` bound to a `Date`, plus `size`, `color`, `variant`, and `disabled` props forwarded to both inputs
- Simplify `SessionEditModal` by replacing four calendar/time refs and update handlers with `startDateTime` / `endDateTime` refs

## Why

The session edit modal duplicated the same date+time input markup and parsing logic for Start and End fields. A shared component reduces duplication and makes the modal easier to maintain.

## Test plan

- [ ] Open the session edit modal for an existing session and confirm start/end date and time display correctly
- [ ] Edit start and end values and save; verify the session updates as expected
- [ ] Create a new session via the modal and confirm default times are populated
- [ ] Confirm the start field is disabled when editing an active session
- [ ] Confirm validation errors still appear when end is before start

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a combined date-and-time input for editing session start and end values in one control.
  * The session editor now uses full datetime values directly, making date/time changes simpler and more consistent.

* **Bug Fixes**
  * Improved validation and duration calculations when adjusting session times.
  * New and existing sessions now load their start and end times more reliably into the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->