### PR TITLE
chore: migrate from lucide-vue-next to @lucide/vue

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { NavigationMenuItem } from '@nuxt/ui'
 import { Timer } from '@lucide/vue'
+import type { NavigationMenuItem } from '@nuxt/ui'
 
 import { useTimerFavicon } from '~/composables/useTimerFavicon.ts'
 import { useTimerState } from '~/composables/useTimerState.ts'

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { NavigationMenuItem } from '@nuxt/ui'
-import { Timer } from 'lucide-vue-next'
+import { Timer } from '@lucide/vue'
 
 import { useTimerFavicon } from '~/composables/useTimerFavicon.ts'
 import { useTimerState } from '~/composables/useTimerState.ts'

--- a/app/components/SessionList.vue
+++ b/app/components/SessionList.vue
@@ -3,7 +3,7 @@
  * SessionList displays and manages time tracking sessions, allowing users to view, edit, and delete session entries.
  */
 
-import { Clock } from 'lucide-vue-next'
+import { Clock } from '@lucide/vue'
 
 import SessionEditModal from '~/components/SessionEditModal.vue'
 import type { DateString, TimeSession } from '~/types/index.ts'

--- a/app/components/ThemeToggle.vue
+++ b/app/components/ThemeToggle.vue
@@ -7,7 +7,7 @@
  * - Accessible label updates based on current state
  */
 
-import { Moon, Sun } from 'lucide-vue-next'
+import { Moon, Sun } from '@lucide/vue'
 
 import { useTheme } from '../composables/useTheme.ts'
 

--- a/app/components/WeekRangeButtons.vue
+++ b/app/components/WeekRangeButtons.vue
@@ -3,7 +3,7 @@
  * A component that displays a range of dates and allows the user to navigate between them.
  */
 
-import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
+import { ChevronLeft, ChevronRight } from '@lucide/vue'
 
 import { formatDate } from '~/utils/formatDate.ts'
 

--- a/app/pages/weekly.vue
+++ b/app/pages/weekly.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useSum } from '@vueuse/math'
 import { Calendar } from '@lucide/vue'
+import { useSum } from '@vueuse/math'
 
 import AppCard from '~/components/AppCard.vue'
 import WeeklyView from '~/components/WeeklyView.vue'

--- a/app/pages/weekly.vue
+++ b/app/pages/weekly.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useSum } from '@vueuse/math'
-import { Calendar } from 'lucide-vue-next'
+import { Calendar } from '@lucide/vue'
 
 import AppCard from '~/components/AppCard.vue'
 import WeeklyView from '~/components/WeeklyView.vue'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	},
 	"dependencies": {
 		"@internationalized/date": "^3.12.2",
+		"@lucide/vue": "^1.24.0",
 		"@nuxt/eslint": "1.16.0",
 		"@nuxt/fonts": "^0.14.0",
 		"@nuxt/ui": "^4.9.0",
@@ -32,7 +33,6 @@
 		"@vueuse/nuxt": "^14.3.0",
 		"dexie": "^4.4.4",
 		"eslint": "^10.6.0",
-		"lucide-vue-next": "^1.0.0",
 		"nuxt": "^4.4.8",
 		"vue": "^3.5.39",
 		"vue-router": "^5.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@internationalized/date':
         specifier: ^3.12.2
         version: 3.12.2
+      '@lucide/vue':
+        specifier: ^1.24.0
+        version: 1.24.0(vue@3.5.39(typescript@6.0.3))
       '@nuxt/eslint':
         specifier: 1.16.0
         version: 1.16.0(@typescript-eslint/utils@8.61.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(crossws@0.4.6(srvx@0.11.16))(esbuild@0.28.0)(eslint@10.6.0(jiti@2.7.0))(magicast@0.5.3)(oxc-parser@0.133.0)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))
@@ -41,9 +44,6 @@ importers:
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
-      lucide-vue-next:
-        specifier: ^1.0.0
-        version: 1.0.0(vue@3.5.39(typescript@6.0.3))
       nuxt:
         specifier: ^4.4.8
         version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@biomejs/biome@2.5.3)(@parcel/watcher@2.5.6)(@types/node@25.9.3)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@10.6.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0)
@@ -1053,6 +1053,11 @@ packages:
 
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
+  '@lucide/vue@1.24.0':
+    resolution: {integrity: sha512-5bNPX0G2YEWdUlBYk7pE8SgDg/f1mkIFpJ9vtE44pW/cwRz7Ioc0tOTESoVJAPvxIELSmYekX+XXIJMjsswNIg==}
+    peerDependencies:
+      vue: '>=3.0.1'
 
   '@mapbox/node-pre-gyp@2.0.3':
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
@@ -5571,12 +5576,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-vue-next@1.0.0:
-    resolution: {integrity: sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==}
-    deprecated: Package deprecated. Please use @lucide/vue instead.
-    peerDependencies:
-      vue: '>=3.0.1'
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -8258,6 +8257,10 @@ snapshots:
       - supports-color
 
   '@kwsites/promise-deferred@1.1.1': {}
+
+  '@lucide/vue@1.24.0(vue@3.5.39(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.39(typescript@6.0.3)
 
   '@mapbox/node-pre-gyp@2.0.3':
     dependencies:
@@ -12967,10 +12970,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lucide-vue-next@1.0.0(vue@3.5.39(typescript@6.0.3)):
-    dependencies:
-      vue: 3.5.39(typescript@6.0.3)
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## Summary

- Replace deprecated `lucide-vue-next` with the official `@lucide/vue` package
- Update icon component imports in 5 Vue files (`app.vue`, `SessionList`, `ThemeToggle`, `WeekRangeButtons`, `weekly`)
- Nuxt UI icon strings (`i-lucide-*`) are unchanged — they use Nuxt Icon, not the Lucide Vue package

## Why

`lucide-vue-next` is deprecated in favor of `@lucide/vue` ([Lucide for Vue docs](https://lucide.dev/guide/packages/lucide-vue)). This keeps the project on the maintained package without changing icon usage or component APIs.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm oxlint --fix`, `pnpm eslint . --fix`, and `pnpm check` pass
- [ ] Verify icons render correctly in the header (`Timer`), session list (`Clock`), week navigation (`ChevronLeft`/`ChevronRight`), theme toggle (`Sun`/`Moon`), and weekly page (`Calendar`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the application’s icon library integration to use `@lucide/vue` for all related icons (timer, clock, sun/moon, chevrons, and calendar).
  * Existing UI elements continue to render the same icons in the same places.
* **Chores**
  * Replaced the previous Lucide icon dependency with the new package in the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->