### PR TITLE
feat: allow editing start time on running sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ logs
 
 # Git worktrees
 .worktrees
+
+# Playwright CLI
+.playwright-cli

--- a/app/components/SessionEditModal.vue
+++ b/app/components/SessionEditModal.vue
@@ -39,13 +39,35 @@ const endDateTime = shallowRef<Date>(new Date())
 
 const isCreateMode = computed(() => !props.session)
 
+const isActiveSession = computed(() => props.session?.isActive ?? false)
+
 const modalTitle = computed(() => (isCreateMode.value ? 'Add session' : 'Edit session'))
 
-const validationErrors = computed(() => validateTimeRange(startDateTime.value, endDateTime.value))
+const validationErrors = computed(() => {
+	if (isActiveSession.value) {
+		const errors = []
+		const now = new Date()
+
+		if (startDateTime.value > now) {
+			errors.push({ field: 'startTime', message: 'Start time cannot be in the future' })
+		}
+
+		const maxDuration = 24 * 60 * 60 * 1000
+		if (now.getTime() - startDateTime.value.getTime() > maxDuration) {
+			errors.push({ field: 'timeRange', message: 'Session cannot be longer than 24 hours' })
+		}
+
+		return errors
+	}
+
+	return validateTimeRange(startDateTime.value, endDateTime.value)
+})
 
 const durationDisplay = computed(() => {
 	if (validationErrors.value.length > 0) return '--:--:--'
-	return formatDuration(calculateDuration(startDateTime.value, endDateTime.value))
+
+	const endTime = isActiveSession.value ? new Date() : endDateTime.value
+	return formatDuration(calculateDuration(startDateTime.value, endTime))
 })
 
 const displayedErrors = computed(() => {
@@ -108,7 +130,9 @@ watch(
 		:description="
 			isCreateMode
 				? 'Set the start and end date and time for the new session.'
-				: 'Adjust the start and end date and time for this session.'
+				: isActiveSession
+					? 'Adjust the start date and time for this running session.'
+					: 'Adjust the start and end date and time for this session.'
 		"
 	>
 		<template #body>
@@ -124,7 +148,7 @@ watch(
 						size="sm"
 						color="neutral"
 						variant="subtle"
-						:disabled="loading || (session?.isActive ?? false)"
+						:disabled="loading"
 					/>
 				</UFormField>
 
@@ -139,9 +163,16 @@ watch(
 						size="sm"
 						color="neutral"
 						variant="subtle"
-						:disabled="loading"
+						:disabled="loading || isActiveSession"
 					/>
 				</UFormField>
+
+				<p
+					v-if="isActiveSession"
+					class="text-sm text-muted"
+				>
+					End time is set when you pause the timer.
+				</p>
 
 				<div class="text-sm text-muted">
 					Duration: <span class="font-mono text-default">{{ durationDisplay }}</span>

--- a/app/components/SessionList.vue
+++ b/app/components/SessionList.vue
@@ -53,10 +53,11 @@ function openEditModal(session: TimeSession): void {
 
 function handleSave(payload: { startTime: Date; endTime: Date }): void {
 	if (editingSession.value) {
-		emit('updateSession', editingSession.value, {
-			startTime: payload.startTime,
-			endTime: payload.endTime,
-		})
+		const updates = editingSession.value.isActive
+			? { startTime: payload.startTime }
+			: { startTime: payload.startTime, endTime: payload.endTime }
+
+		emit('updateSession', editingSession.value, updates)
 		return
 	}
 
@@ -146,7 +147,7 @@ function getTimeRangeDisplay(session: TimeSession): string {
 							type="button"
 							class="text-left text-sm font-mono truncate hover:underline disabled:no-underline disabled:cursor-default"
 							:class="{ 'text-inverted': session.isActive }"
-							:disabled="loading || session.isActive"
+							:disabled="loading"
 							@click="openEditModal(session)"
 						>
 							{{ getTimeRangeDisplay(session) }}
@@ -161,14 +162,13 @@ function getTimeRangeDisplay(session: TimeSession): string {
 					<!-- Actions -->
 					<div class="flex items-center gap-1">
 						<UButton
-							v-if="!session.isActive"
 							icon="i-lucide-pencil"
 							size="md"
 							color="neutral"
 							variant="soft"
 							:disabled="loading"
-							title="Edit session"
-							aria-label="Edit session"
+							:title="session.isActive ? 'Edit start time' : 'Edit session'"
+							:aria-label="session.isActive ? 'Edit start time' : 'Edit session'"
 							@click="openEditModal(session)"
 						/>
 						<UButton

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -28,6 +28,7 @@ const {
 	loading: sessionLoading,
 } = useSessionManager(async () => {
 	await loadWeeklyStats()
+	await loadActiveSession()
 })
 
 async function handleCreateSession(payload: { startTime: Date; endTime: Date }): Promise<void> {

--- a/app/utils/sessionMutations.spec.ts
+++ b/app/utils/sessionMutations.spec.ts
@@ -65,4 +65,22 @@ describe('persistSessionUpdate', () => {
 
 		expect(checkForOverlappingSessions).toHaveBeenCalledWith(startTime, session.endTime, session.id)
 	})
+
+	it('should validate overlap using current time when active session start time changes', async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2023-06-15T10:00:00'))
+
+		const activeSession = { ...session, isActive: true, endTime: undefined }
+		const startTime = new Date('2023-06-15T08:00:00')
+
+		await persistSessionUpdate(activeSession, { startTime })
+
+		expect(checkForOverlappingSessions).toHaveBeenCalledWith(
+			startTime,
+			new Date('2023-06-15T10:00:00'),
+			activeSession.id,
+		)
+
+		vi.useRealTimers()
+	})
 })

--- a/app/utils/sessionMutations.ts
+++ b/app/utils/sessionMutations.ts
@@ -54,10 +54,13 @@ export async function persistSessionUpdate(
 	const startTime = updates.startTime ?? session.startTime
 	const endTime = updates.endTime ?? session.endTime
 	const hasTimeUpdate = 'startTime' in updates || 'endTime' in updates
-	const shouldValidateOverlap = hasTimeUpdate && Boolean(endTime)
 
-	if (shouldValidateOverlap && endTime) {
-		await assertNoOverlappingSessions(startTime, endTime, session.id)
+	if (hasTimeUpdate) {
+		const overlapEndTime = endTime ?? (session.isActive ? new Date() : undefined)
+
+		if (overlapEndTime) {
+			await assertNoOverlappingSessions(startTime, overlapEndTime, session.id)
+		}
 	}
 
 	await updateSession(session.id, normalizeSessionUpdates(session, updates))


### PR DESCRIPTION
## Summary

Running sessions previously blocked start-time edits, which made it awkward to correct a mistyped start without pausing the timer first. This PR enables start-time editing for active sessions while keeping end time read-only until pause.

- Enable the edit modal and start-time input for active sessions
- Keep end time disabled for running sessions, with a helper message
- Validate active-session edits (no future start, max 24h duration) and check overlaps using the current time as the end boundary
- Sync timer state after session updates so the live duration stays accurate
- Add `.playwright-cli` to `.gitignore`

## Test plan

- [x] `pnpm test app/utils/sessionMutations.spec.ts --run`
- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] Manual verification with playwright-cli: start timer, open edit modal, change start time, confirm save updates session display and timer duration while session keeps running

Made with [Cursor](https://cursor.com)