### PR TITLE
refactor: remove unused loading prop from TimerDisplay

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
-	"entry": ["app/test/setup.ts"],
+	"entry": ["app/test/setup.ts", "eslint/eslint-clean-json.ts"],
 	"ignorePatterns": ["**/*.d.ts"],
-	"ignoreDependencies": ["@typescript-eslint/parser", "@nuxt/fonts"],
+	"ignoreDependencies": ["@typescript-eslint/parser", "@nuxt/fonts", "nuxt"],
 	"rules": {
 		"unresolved-imports": "error",
 		"unlisted-dependencies": "error",

--- a/app/components/TimerDisplay.vue
+++ b/app/components/TimerDisplay.vue
@@ -17,8 +17,7 @@ withDefaults(
 		/** Total duration for this week in milliseconds. */
 		weekTotalDuration: Milliseconds
 	}>(),
-	{
-	},
+	{},
 )
 
 defineEmits<{

--- a/app/components/TimerDisplay.vue
+++ b/app/components/TimerDisplay.vue
@@ -16,11 +16,8 @@ withDefaults(
 		todaysTotalDuration: Milliseconds
 		/** Total duration for this week in milliseconds. */
 		weekTotalDuration: Milliseconds
-		/** Whether the timer is in a loading state. */
-		loading?: boolean
 	}>(),
 	{
-		loading: false,
 	},
 )
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -13,8 +13,7 @@ import { initDatabase } from '~/utils/database.ts'
 
 const { dailyStats, loadWeeklyStats } = useWeeklyStats()
 
-const { loadActiveSession, timerState, currentSessionDuration, toggleTimer, loading } =
-	useTimerState()
+const { loadActiveSession, timerState, currentSessionDuration, toggleTimer } = useTimerState()
 
 const {
 	sessions,
@@ -94,7 +93,6 @@ useSeoMeta({
 					:current-session-duration="currentSessionDuration"
 					:todays-total-duration="todaysTotalDuration"
 					:week-total-duration="weekTotalDuration"
-					:loading="loading"
 					@toggle-timer="toggleTimer"
 				/>
 			</div>


### PR DESCRIPTION
## Summary

- Remove the unused `loading` prop from `TimerDisplay`, which was defined but never referenced in the component template
- Stop passing `loading` from the home page and remove the unused destructuring from `useTimerState`
- Update `.fallowrc.json` to add the eslint config entry point and ignore the `nuxt` dependency for fallow analysis

## Test plan

- [ ] Open the home page and confirm the timer display renders correctly (current session, today's total, this week's total)
- [ ] Start and pause the timer to verify controls still work
- [ ] Confirm no Vue warnings about extraneous non-props attributes on `TimerDisplay`
- [ ] Run `pnpm fallow audit` and confirm no new unresolved-import or unlisted-dependency errors


Made with [Cursor](https://cursor.com)