### PR TITLE
fix: close session edit modal after successful save

### DIFF
--- a/app/components/SessionList.vue
+++ b/app/components/SessionList.vue
@@ -64,6 +64,12 @@ function handleSave(payload: { startTime: Date; endTime: Date }): void {
 	emit('createSession', payload)
 }
 
+function closeModal(): void {
+	isModalOpen.value = false
+}
+
+defineExpose({ closeModal })
+
 watch(isModalOpen, (open) => {
 	if (!open) {
 		editingSession.value = null

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -30,8 +30,13 @@ const {
 	await loadActiveSession()
 })
 
+const sessionListRef = useTemplateRef('sessionListRef')
+
 async function handleCreateSession(payload: { startTime: Date; endTime: Date }): Promise<void> {
 	await createSession(payload.startTime, payload.endTime)
+	if (!errorMessage.value) {
+		sessionListRef.value?.closeModal()
+	}
 }
 
 async function handleUpdateSession(
@@ -39,6 +44,9 @@ async function handleUpdateSession(
 	updates: Parameters<typeof updateSessionData>[1],
 ): Promise<void> {
 	await updateSessionData(session, updates)
+	if (!errorMessage.value) {
+		sessionListRef.value?.closeModal()
+	}
 }
 
 // Initialize on mount
@@ -104,6 +112,7 @@ useSeoMeta({
 				</div>
 
 				<SessionList
+					ref="sessionListRef"
 					:sessions="sessions"
 					:selected-date="selectedDate"
 					:loading="sessionLoading"


### PR DESCRIPTION
## Summary

- Close the session create/edit modal automatically after a successful save
- Expose `closeModal()` from `SessionList` and call it from the dashboard page handlers when `errorMessage` is empty
- Keeps the modal open when validation or persistence fails so users can see and fix errors

## Why

After editing session start/end times and clicking Save, the modal remained open. That felt broken because Cancel closes the dialog but Save did not, even when the update succeeded.

## Test plan

- [x] Verified with playwright-cli: create session → modal closes after Add session
- [x] Verified with playwright-cli: edit session → modal closes after Save
- [ ] Manual: confirm modal stays open when save fails (e.g. overlapping session)

Made with [Cursor](https://cursor.com)